### PR TITLE
Add PhyllotaxisBloom pattern, fix EEPROM wear and millis() truncation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,63 @@ Board: Adafruit QT Py (SAMD21)
 Libraries:
 * FastLED v3.5.0: https://github.com/FastLED/FastLED
 * Adafruit FreeTouch Library v1.1.1: https://github.com/adafruit/Adafruit_FreeTouch
+
+### Pattern Catalog (SimplePatternList — 18 patterns)
+
+
+| # | Function | File | Description |
+|---|----------|------|-------------|
+| 0 | `colorWavesFibonacci` | Patterns.h | Mark Kriegsman's color waves rendered in Fibonacci spiral order |
+| 1 | `prideFibonacci` | Patterns.h | Pride2015 rainbow animation rendered in Fibonacci spiral order |
+| 2 | `outwardPalettes` | Patterns.h | Current palette mapped outward along Fibonacci index |
+| 3 | `outwardRainbow` | Patterns.h | HSV rainbow mapped outward along Fibonacci index |
+| 4 | `cube` | PatternCube.h | Wireframe 3D cube projected onto LEDs with back-face culling and organic rotation |
+| 5 | `fibonacciChase` | PatternFibonacciSpiral.h | Bright pulses chase along each Fibonacci spiral arm in sequence |
+| 6 | `wave` | PatternWave.h | Quadwave dots along sine curves with random orientation, mirroring, and slow rotation |
+| 7 | `sublimeVerticalFire` | PatternSublime.h | Particle-based embers rising bottom-to-top with HeatColors palette |
+| 8 | `sublimeRain` | PatternSublime.h | Matrix-style green drops falling top-to-bottom with fading trails |
+| 9 | `phyllotaxisBloomAnimation` | PatternPhyllotaxisBloom.h | Golden-angle hue distribution with dual 5-arm/8-arm interference waves drifting at phi-ratio speeds — sunflower parastichy rendered as bioluminescent ripples |
+| 10 | `flock` | PatternsAurora.h | Boids flocking simulation with separation/cohesion/alignment + predator |
+| 11 | `attract` | PatternsAurora.h | Boids orbiting a gravitational attractor at center with swirling trails |
+| 12 | `incrementalDrift` | PatternsAurora.h | Concentric rings of dots orbiting at incrementally different speeds |
+| 13 | `incrementalDrift2` | PatternsAurora.h | Two mirrored groups of orbiting dots creating rose/flower patterns |
+| 14 | `pendulumWave` | PatternsAurora.h | 32 pendulum dots swinging at incrementally different frequencies |
+| 15 | `spiral` | PatternsAurora.h | Two rotating spiral arms with oscillating tightness and width |
+| 16 | `swirl` | PatternsAurora.h | Six symmetric bouncing dots with fading trails |
+| 17 | `electricMandala` | PatternsAurora.h | Perlin noise with kaleidoscope symmetry (4-fold rotation + diagonal mirror) and slow rotation |
+
+**Additional pattern functions** (defined but not in `patterns[]`):
+
+| # | Function | File | Description |
+|---|----------|------|-------------|
+| - | `fibonacciSpiral` | PatternFibonacciSpiral.h | Two overlapping Fibonacci spiral arm systems (e.g. 5+8 arms) creating moiré interference with breathing center bloom |
+| - | `sublimeFire` | PatternSublime.h | Radial fire simulation — heat rises from edge toward center with angular Perlin noise |
+| - | `sublimeJuggle` | PatternSublime.h | Colored dots weaving in/out of sync along radial paths, parameters shift every 10s |
+| - | `sublimeBpm` | PatternSublime.h | Radial bands pulsing outward at 62 BPM, colored through current palette |
+| - | `sublimeSinelon` | PatternSublime.h | Single colored dot sweeping center-to-edge and back with fading trails |
+| - | `radar` | PatternsAurora.h | Sweeping radar arm with long fading trail, colored by radius |
+| - | `plasma` | PatternsAurora.h | Classic RGB plasma using cos_wave lookup table with gamma correction |
+| - | `rotatingPalettes` | Patterns.h | Current palette mapped by angle (rotating) |
+| - | `rotatingRainbow` | Patterns.h | HSV rainbow mapped by angle (rotating) |
+| - | `horizontalRainbow` | Patterns.h | HSV rainbow mapped by X coordinate |
+| - | `verticalRainbow` | Patterns.h | HSV rainbow mapped by Y coordinate |
+| - | `diagonalRainbow` | Patterns.h | HSV rainbow mapped by X+Y |
+| - | `colorTest` | Patterns.h | Cycles through solid R/G/B/W/Black every 2s (diagnostic) |
+
+### Key Design Patterns
+
+**Pattern system:** A `patterns[]` array of function pointers (18 entries) drives animation selection. The current index is persisted to EEPROM and advances on each device reset.
+
+**Proximity-based rendering:** Since LEDs are scattered (not on a grid), most patterns work by computing virtual object positions (dots, edges, particles) then lighting each LED based on squared-distance proximity (`dSq < proxSq`). This avoids sqrt and enables soft falloff.
+
+**PatternRotation system:** A reusable struct (`Patterns.h:781`) that adds slow, organic rotation to patterns. Uses sinusoidal angular velocity (speeds up, slows, pauses, reverses) with randomized parameters, refreshed every 8 seconds.
+
+**Touch system:** Three `Adafruit_FreeTouch` sensors (pins A3, A6, A7) are calibrated via min/max arrays and mapped to XY coordinates in 0–255 space. Touch events produce expanding circle overlays via `touchDemo()`. When waves are active, the current pattern is suppressed.
+
+**LED mapping:** Four coordinate arrays in `Map.h` map physical LED indices:
+- `coordsX[]`/`coordsY[]` — 2D Cartesian position (0–255)
+- `angles[]` — angular position (0–255 = 0°–360°)
+- `radius[]` — distance from center (0–255)
+- `physicalToFibonacci[]`/`fibonacciToPhysical[]` — bidirectional mapping between physical LED index and Fibonacci spiral order
+
+**Color palettes:** 34 cpt-city gradient palettes in `GradientPalettes.h` are blended smoothly with `nblendPaletteTowardPalette()`. Target palette auto-cycles every 10 seconds.

--- a/fibonacci128-touch-demo/PatternFibonacciSpiral.h
+++ b/fibonacci128-touch-demo/PatternFibonacciSpiral.h
@@ -23,7 +23,7 @@ void fibonacciSpiral()
   uint8_t arms1 = armPairs[pairIdx][0];
   uint8_t arms2 = armPairs[pairIdx][1];
 
-  uint16_t ms = millis();
+  uint32_t ms = millis();
   uint8_t timeA = ms / 11;  // outward pulse phase
   uint8_t timeB = ms / 17;  // counter-pulse phase
   uint8_t timeHue = ms / 37; // slow color rotation

--- a/fibonacci128-touch-demo/PatternPhyllotaxisBloom.h
+++ b/fibonacci128-touch-demo/PatternPhyllotaxisBloom.h
@@ -1,0 +1,67 @@
+// Phyllotaxis Bloom - inspired by the golden angle arrangement of seeds in sunflowers.
+//
+// Each LED is colored using the golden angle (137.5°) in hue space, exactly as
+// sunflower seeds are arranged 137.5° apart in physical space. This spacing is
+// irrational relative to 360°, so colors never cluster or repeat — producing the
+// maximally uniform, non-repeating distribution seen in nature.
+//
+// Two interference waves (5-arm and 8-arm — consecutive Fibonacci numbers) travel
+// along the spiral arms at phi-ratio speeds (time divisors 8 and 13 — also
+// consecutive Fibonacci numbers). They never phase-lock, producing ~40 drifting
+// bright nodes where waves reinforce — like bioluminescent ripples on a living spiral.
+//
+// The 5×8 arm counts are exactly the parastichy numbers you count on a sunflower.
+
+#ifndef PatternPhyllotaxisBloom_H
+#define PatternPhyllotaxisBloom_H
+
+
+void phyllotaxisBloomAnimation()
+{
+  uint32_t ms = millis();
+
+  // Phi-ratio time bases: consecutive Fibonacci divisors (8, 13) keep the two
+  // waves drifting at ~phi relative speed — they never lock into a repeating pattern.
+  uint8_t timeA   = (uint8_t)(ms / 8);   // 5-arm wave: travels outward
+  uint8_t timeB   = (uint8_t)(ms / 13);  // 8-arm wave: travels inward (phi-ratio slower)
+  uint8_t timeHue = (uint8_t)(ms / 80);  // hue rotation: ~20s full spectrum cycle
+
+  // Golden angle in 0-255 hue space: 137.508/360 * 256 = 97.8 → 98.
+  // fibIdx * 98 places each successive Fibonacci LED 137.5° away in hue,
+  // making 5-arm and 8-arm spiral arms visible as distinct color bands.
+  const uint8_t GOLDEN_ANGLE_8 = 98;
+
+  for (uint16_t i = 0; i < NUM_LEDS; i++) {
+    uint8_t fibIdx = physicalToFibonacci[i];
+
+    // Hue: golden-angle distribution reveals the spiral arm structure as color bands.
+    // 5 Fibonacci steps ≈ 5×137.5° = 687.5° ≡ 327.5° — one full lap minus a small gap,
+    // so every 5th LED is nearly the same hue, tracing the 5 spiral arms.
+    // Similarly for 8 arms. Exactly the parastichy visible in a sunflower.
+    uint8_t hue = (uint8_t)(fibIdx * GOLDEN_ANGLE_8) + timeHue;
+
+    // 5-arm spiral wave: spatial frequency 5 places one crest per spiral arm.
+    // All 5 arms brighten and dim together as timeA advances outward.
+    uint8_t wave1 = sin8(fibIdx * 5 - timeA);
+
+    // 8-arm counter-wave: travels inward at phi-ratio slower speed.
+    // Spatial freq 8 = one crest per 8-arm spiral arm.
+    uint8_t wave2 = sin8(fibIdx * 8 + timeB);
+
+    // Multiplicative interference: bright only where both waves crest simultaneously.
+    // Produces ~40 drifting nodes (5×8 intersections) that travel along the arms —
+    // like the growing tip of each spiral arm lighting up in sequence.
+    uint8_t bri = scale8(wave1, wave2);
+
+    // Soft glow floor: dark regions stay gently lit, like a starfield behind the bloom.
+    bri = qadd8(bri, 15);
+
+    // Saturation dip at brightness peaks: white-tipped "petal" effect.
+    // Bright nodes bloom toward white before fading back to saturated color.
+    uint8_t sat = 255 - scale8(bri, 80);
+
+    leds[i] = CHSV(hue, sat, bri);
+  }
+}
+
+#endif

--- a/fibonacci128-touch-demo/Patterns.h
+++ b/fibonacci128-touch-demo/Patterns.h
@@ -39,6 +39,7 @@ struct PatternRotation {
 #include "PatternFibonacciSpiral.h"
 #include "PatternSublime.h"
 #include "PatternWave.h"
+#include "PatternPhyllotaxisBloom.h"
 
 // ColorWavesWithPalettes by Mark Kriegsman: https://gist.github.com/kriegsman/8281905786e8b2632aeb
 // This function draws color waves with an ever-changing,

--- a/fibonacci128-touch-demo/fibonacci128-touch-demo.ino
+++ b/fibonacci128-touch-demo/fibonacci128-touch-demo.ino
@@ -94,6 +94,7 @@ SimplePatternList patterns = {
   wave,
   sublimeVerticalFire,
   sublimeRain,
+  phyllotaxisBloomAnimation,
 
   flock,
   attract,
@@ -170,30 +171,70 @@ void loop() {
   FastLED.delay(1000 / FRAMES_PER_SECOND);
 }
 
+// EEPROM wear-leveling for pattern index persistence.
+//
+// Problem: The SAMD21 uses flash-based EEPROM emulation (FlashStorage_SAMD).
+// Each commit() erases and rewrites an entire flash page. SAMD21 flash is rated
+// for ~25K erase cycles (some datasheets say 10K conservative). Writing on every
+// boot would exhaust the flash in months of frequent power-cycling.
+//
+// Solution: Rotate writes across SLOT_COUNT addresses. Each slot holds the
+// pattern index or 0xFF (erased). On boot we scan for the last written slot
+// (the one followed by an empty slot or at the end of the ring). We advance
+// to the next slot and write there. The flash page is only erased once every
+// SLOT_COUNT boots, extending endurance by that factor.
+//
+// With 64 slots and 25K cycles, the device survives ~1.6 million boots.
+
+#define SLOT_COUNT 64  // number of wear-leveling slots (one byte each)
+
 void readEeprom() {
   Serial.print("EEPROM length: ");
   Serial.println(EEPROM.length());
 
-  uint16_t address = 0;
-  int number;
+  // Find the current slot: scan for the last valid entry before an empty (0xFF) slot.
+  // In a freshly erased EEPROM all slots are 0xFF, so currentSlot stays 0 and
+  // we treat the value as invalid (triggering pattern index 0).
+  uint16_t currentSlot = 0;
+  bool foundValid = false;
 
-  // Read the content of emulated-EEPROM
-  EEPROM.get(address, number);
+  for (uint16_t i = 0; i < SLOT_COUNT; i++) {
+    uint8_t val;
+    EEPROM.get(i, val);
+    if (val != 0xFF) {
+      currentSlot = i;
+      foundValid = true;
+    }
+  }
 
-  if (number >= patternCount || number < 0) number = 0;
+  // Read pattern index from current slot
+  uint8_t storedIndex = 0;
+  if (foundValid) {
+    EEPROM.get(currentSlot, storedIndex);
+  }
 
-  currentPatternIndex = number;
+  if (storedIndex >= patternCount) storedIndex = 0;
+  currentPatternIndex = storedIndex;
 
-  // Print the current number on the serial monitor
-  Serial.print("Number = 0x");
-  Serial.println(number, HEX);
+  Serial.print("Slot = ");
+  Serial.print(currentSlot);
+  Serial.print(", Pattern = ");
+  Serial.println(storedIndex);
 
-  // Save into emulated-EEPROM the number increased by 1 for the next run of the sketch
-  EEPROM.put(address, (int) (number + 1));
+  // Compute next pattern and next slot
+  uint8_t nextIndex = (storedIndex + 1) % patternCount;
+  uint16_t nextSlot = (currentSlot + 1) % SLOT_COUNT;
 
-  if (!EEPROM.getCommitASAP())
-  {
-    Serial.println("CommitASAP not set. Need commit()");
+  // If we wrapped around to slot 0, all slots are full — erase them first
+  if (nextSlot == 0) {
+    for (uint16_t i = 0; i < SLOT_COUNT; i++) {
+      EEPROM.put(i, (uint8_t)0xFF);
+    }
+  }
+
+  EEPROM.put(nextSlot, nextIndex);
+
+  if (!EEPROM.getCommitASAP()) {
     EEPROM.commit();
   }
 


### PR DESCRIPTION
- Add PatternPhyllotaxisBloom.h: golden-angle hue distribution with dual 5-arm/8-arm interference waves at phi-ratio speeds
- Fix EEPROM wear: replace single-address write with 64-slot wear-leveling ring buffer, extending flash endurance from ~25K to ~1.6M boots
- Fix millis() truncation in fibonacciSpiral(): uint16_t -> uint32_t to eliminate visual glitch every ~65 seconds
- Update README.md: reorder pattern catalog to match patterns[] array, fix function names and file attributions, add phyllotaxisBloomAnimation